### PR TITLE
Travis pr build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - '6'
 
+script:
+- npm install
+- "if [[ \"$TRAVIS_PULL_REQUEST\" = \"false\" ]]; then npm run test ; else npm run lint ; fi"
+
 before_install: "if [[ \"$TRAVIS_PULL_REQUEST\" = \"false\" ]]; then openssl aes-256-cbc -K $encrypted_369f74a373d5_key -iv $encrypted_369f74a373d5_iv -in secrets.tar.enc -out secrets.tar -d ; tar xvf secrets.tar ; fi"
 
 deploy:


### PR DESCRIPTION
`npm test` still failing on PR due to a missing `.pem` file.

This PR instructs Travis to run `lint` on PRs and `npm test` on branches (currently `master` and `develop`)

Let's see if we can see a green build this time :-)