### PR TITLE
Maoo fix clabot project resolution

### DIFF
--- a/githubApi.js
+++ b/githubApi.js
@@ -7,7 +7,7 @@ const getOrgConfigUrl = (repositoryUrl) => {
   return ghUrl;
 };
 
-exports.githubRequest = (opts, token, errorHandler) =>
+exports.githubRequest = (opts, token) =>
     requestp(Object.assign({}, {
       json: true,
       headers: {
@@ -15,7 +15,7 @@ exports.githubRequest = (opts, token, errorHandler) =>
         'User-Agent': 'github-cla-bot'
       },
       method: 'POST'
-    }, opts), errorHandler);
+    }, opts));
 
 exports.getOrgConfig = ({webhook}) => ({
   url: getOrgConfigUrl(webhook.repository.url),

--- a/githubApi.js
+++ b/githubApi.js
@@ -7,7 +7,7 @@ const getOrgConfigUrl = (repositoryUrl) => {
   return ghUrl;
 };
 
-exports.githubRequest = (opts, token) =>
+exports.githubRequest = (opts, token, errorHandler) =>
     requestp(Object.assign({}, {
       json: true,
       headers: {
@@ -15,7 +15,7 @@ exports.githubRequest = (opts, token) =>
         'User-Agent': 'github-cla-bot'
       },
       method: 'POST'
-    }, opts));
+    }, opts), errorHandler);
 
 exports.getOrgConfig = ({webhook}) => ({
   url: getOrgConfigUrl(webhook.repository.url),

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const validAction = (action) =>
 exports.handler = ({ body }, lambdaContext, callback) => {
 
   const loggingCallback = (err, message) => {
-    console.log('callback', err, message);
+    console.info('callback', err, message);
     callback(err, message);
   };
 
@@ -28,7 +28,7 @@ exports.handler = ({ body }, lambdaContext, callback) => {
     webhook: body
   };
 
-  console.log(`Checking CLAs for PR ${context.webhook.pull_request.url}`);
+  console.info(`Checking CLAs for PR ${context.webhook.pull_request.url}`);
 
   githubRequest(getOrgConfig(context), clabotToken)
     // if the request to obtain the org-level .clabot file returns a non 2xx response
@@ -37,7 +37,7 @@ exports.handler = ({ body }, lambdaContext, callback) => {
     .catch(() => ({ noOrgConfig }))
     .then(body => {
       if (!body.noOrgConfig) {
-        console.log('Resolving .clabot at project level');
+        console.info('Resolving .clabot at project level');
         return githubRequest(getReadmeUrl(context), clabotToken);
       }
       return body;

--- a/index.js
+++ b/index.js
@@ -36,11 +36,13 @@ exports.handler = ({ body }, lambdaContext, callback) => {
     // project level file should be requested
     .catch(() => ({ noOrgConfig }))
     .then(body => {
-      if (!body.noOrgConfig) {
+      if ('noOrgConfig' in body) {
         console.info('Resolving .clabot at project level');
         return githubRequest(getReadmeUrl(context), clabotToken);
+      } else {
+        console.info('Using org-level .clabot');
+        return body;
       }
-      return body;
     })
     .then(body => githubRequest(getFile(body), clabotToken))
     .then(config => {

--- a/index.js
+++ b/index.js
@@ -27,10 +27,15 @@ exports.handler = ({ body }, lambdaContext, callback) => {
 
   console.log(`Checking CLAs for PR ${context.webhook.pull_request.url}`);
 
-  githubRequest(getOrgConfig(context), clabotToken)
+  githubRequest(getOrgConfig(context), clabotToken, (response) => {
+    // Defining (inline) a error handling function to avoid failing if configuration
+    // cannot be resolved at organisation level
+    console.log("Couldn't fetch .clabot from Github organisation project");
+    return { orgConfig: false };
+  })
     .then(body => {
-      if (!body.name || body.name === '') {
-        console.log("Couldn't fetch .clabot from Github organisation project; trying at project level");
+      if (!body['orgConfig']) {
+        console.log('Resolving .clabot at project level');
         return githubRequest(getReadmeUrl(context), clabotToken);
       }
       return body;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "execute": "node-lambda run --configFile deploy.env",
     "deploy": "node-lambda deploy --configFile deploy.env",
     "test": "npm run lint && jasmine",
-    "lint": "eslint --ignore-path .gitignore *.js"
+    "lint": "eslint --ignore-path .gitignore \"**/*.js\""
   },
   "author": "",
   "license": "ISC",
@@ -24,6 +24,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "jasmine": "^2.6.0",
+    "jasmine-spec-reporter": "^4.1.0",
     "mock-require": "^2.0.2",
     "node-lambda": "^0.9.0"
   }

--- a/requestAsPromise.js
+++ b/requestAsPromise.js
@@ -1,12 +1,16 @@
 const request = require('request');
 
-module.exports = (opts) => new Promise((resolve, reject) => {
+module.exports = (opts, errorHandler) => new Promise((resolve, reject) => {
   console.log('API Request', opts.url, opts.body || {});
   request(opts, (error, response, body) => {
     if (error) {
       reject(error.toString());
     } else if (response && response.statusCode && !response.statusCode.toString().startsWith('2')) {
-      reject(new Error(`API request ${opts.url} failed with status ${response.statusCode}`));
+      if (errorHandler) {
+        resolve(errorHandler(response));
+      } else {
+        reject(new Error(`API request ${opts.url} failed with status ${response.statusCode}`));
+      }
     } else {
       resolve(body);
     }

--- a/requestAsPromise.js
+++ b/requestAsPromise.js
@@ -1,7 +1,7 @@
 const request = require('request');
 
 module.exports = (opts) => new Promise((resolve, reject) => {
-  console.log('API Request', opts.url, opts.body || {});
+  console.info('API Request', opts.url, opts.body || {});
   request(opts, (error, response, body) => {
     if (error) {
       reject(error.toString());

--- a/requestAsPromise.js
+++ b/requestAsPromise.js
@@ -1,16 +1,12 @@
 const request = require('request');
 
-module.exports = (opts, errorHandler) => new Promise((resolve, reject) => {
+module.exports = (opts) => new Promise((resolve, reject) => {
   console.log('API Request', opts.url, opts.body || {});
   request(opts, (error, response, body) => {
     if (error) {
       reject(error.toString());
     } else if (response && response.statusCode && !response.statusCode.toString().startsWith('2')) {
-      if (errorHandler) {
-        resolve(errorHandler(response));
-      } else {
-        reject(new Error(`API request ${opts.url} failed with status ${response.statusCode}`));
-      }
+      reject(new Error(`API request ${opts.url} failed with status ${response.statusCode}`));
     } else {
       resolve(body);
     }

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,6 +1,8 @@
 /* globals jasmine */
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
+console.info = () => {};
+
 jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(new SpecReporter({
   spec: {

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,0 +1,12 @@
+/* globals jasmine */
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+
+jasmine.getEnv().clearReporters();
+jasmine.getEnv().addReporter(new SpecReporter({
+  spec: {
+    displayPending: true
+  },
+  summary: {
+    displayDuration: false
+  }
+}));

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -69,13 +69,10 @@ describe('lambda function', () => {
 
     // mock the typical requests that the lambda function makes
     mockConfig = {
-      // // the bot first checks for an org-level config file
+      // the bot first checks for an org-level config file
       'https://foo.com/repos/user/clabot-config/contents/.clabot': {
         // it returns an empty body, as a result a repo-local config file is used
-        body: {},
-        response: {
-          statusCode: 404
-        }
+        body: {}
       },
       // next step is to make a request for the download URL for the cla config
       'http://foo.com/user/repo/contents/.clabot': {

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -152,7 +152,6 @@ describe('lambda function', () => {
       mock('request', request);
       const lambda = require('../index');
 
-      const util = require('util');
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
@@ -171,20 +170,18 @@ describe('lambda function', () => {
           response: {
             statusCode: 404
           }
-        },
+        }
       }));
 
       mock('request', request);
       const lambda = require('../index');
 
-      const util = require('util');
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toEqual('Error: API request http://foo.com/user/repo/contents/.clabot failed with status 404');
           done();
         });
     });
-
 
   });
 

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -18,7 +18,7 @@ process.env.INTEGRATION_ENABLED = true;
 // request options
 const mockRequest = ({error, response, body, verifyRequest = noop}) =>
   (opts, cb) => {
-    console.log('Mocking response for ' + opts.url);
+    console.info('Mocking response for ' + opts.url);
     verifyRequest(opts, cb);
     cb(error, response, body);
   };
@@ -140,6 +140,10 @@ describe('lambda function', () => {
       });
     });
 
+  });
+
+  describe('clabot configuration resolution', () => {
+
     it('should resolve .clabot on project root, if clabot-config is not present at org-level', (done) => {
       const request = mockMultiRequest(merge(mockConfig, {
         'https://foo.com/repos/user/clabot-config/contents/.clabot': {
@@ -259,7 +263,7 @@ describe('lambda function', () => {
         });
     });
 
-    it('should comment ans set status on pull requests where a CLA has not been signed', (done) => {
+    it('should comment and set status on pull requests where a CLA has not been signed', (done) => {
       const request = mockMultiRequest(merge(mockConfig, {
         'http://foo.com/user/repo/statuses/1234': {
           verifyRequest: (opts) => {


### PR DESCRIPTION
```
Spec started

  lambda function
    ✓ should ignore actions that are not pull requests being opened

    HTTP issues
      * should propagate HTTP request errors

    clabot configuration resolution
      ✓ should resolve .clabot on project root, if clabot-config is not present at org-level
      ✓ should fail if no .clabot is provided

    authorization tokens
      ✓ should add the bot GitHub auth token for the initial requests
      ✓ should use the clients auth token for labelling and status

    pull requests opened
      ✓ should label and set status on pull requests from users with a signed CLA
      ✓ should comment ans set status on pull requests where a CLA has not been signed
      ✓ should report the names of all committers without CLA

    contributor check configuration
      ✓ should support fetching of contributor list from a Github API URL
      ✓ should support fetching of contributor list from a URL
      ✓ should support fetching of contributors via a webhook

    pull requests updated
      ✓ should label and add status check on pull requests and update stats for users with a signed CLA
      ✓ should comment and remove label / status check on pull requests where a CLA has not been signed

**************************************************
*                    Pending                     *
**************************************************

1) lambda function HTTP issues should propagate HTTP request errors
  Temporarily disabled with xit

Executed 13 of 14 specs INCOMPLETE (1 PENDING).
```