### PR TITLE
Improve issue comment

### DIFF
--- a/event.json
+++ b/event.json
@@ -5,7 +5,7 @@
       "url": "https://api.github.com/repos/symphonyoss/symphony-java-sample-bots/pulls/11",
       "issue_url": "https://api.github.com/repos/symphonyoss/symphony-java-sample-bots/issues/11",
       "head": {
-        "sha": "462eecdd0d4c822e64dafc774974f21e91ddd305"
+        "sha": "df0e813acac48351b91712bba00d39e44c5ffa63"
       }
     },
     "repository": {

--- a/githubApi.js
+++ b/githubApi.js
@@ -1,3 +1,4 @@
+const handlebars = require('handlebars');
 const requestp = require('./requestAsPromise');
 const gh = require('parse-github-url');
 
@@ -56,9 +57,9 @@ exports.setStatus = ({webhook}, state) => ({
   }
 });
 
-exports.addComment = ({webhook, config}, message) => ({
+exports.addComment = ({webhook, config}, usersWithoutCLA) => ({
   url: webhook.pull_request.issue_url + '/comments',
   body: {
-    body: config.message + "\n\n" + message
+    body: handlebars.compile(config.message)
   }
 });

--- a/githubApi.js
+++ b/githubApi.js
@@ -58,7 +58,8 @@ exports.setStatus = ({webhook}, state) => ({
 });
 
 exports.addComment = ({webhook, config}, usersWithoutCLA) => {
-  var message = (config.message.indexOf('usersWithoutCLA') > 0) ? handlebars.compile(config.message) : config.message;
+  const template = handlebars.compile(config.message);
+  const message = template(this);
   return ({
     url: webhook.pull_request.issue_url + '/comments',
     body: {

--- a/githubApi.js
+++ b/githubApi.js
@@ -57,9 +57,12 @@ exports.setStatus = ({webhook}, state) => ({
   }
 });
 
-exports.addComment = ({webhook, config}, usersWithoutCLA) => ({
-  url: webhook.pull_request.issue_url + '/comments',
-  body: {
-    body: handlebars.compile(config.message)
-  }
-});
+exports.addComment = ({webhook, config}, usersWithoutCLA) => {
+  var message = (config.message.indexOf('usersWithoutCLA') > 0) ? handlebars.compile(config.message) : config.message;
+  return ({
+    url: webhook.pull_request.issue_url + '/comments',
+    body: {
+      body: message
+    }
+  });
+};

--- a/githubApi.js
+++ b/githubApi.js
@@ -56,9 +56,9 @@ exports.setStatus = ({webhook}, state) => ({
   }
 });
 
-exports.addComment = ({webhook, config}) => ({
+exports.addComment = ({webhook, config}, message) => ({
   url: webhook.pull_request.issue_url + '/comments',
   body: {
-    body: config.message
+    body: config.message + "\n\n" + message
   }
 });

--- a/index.js
+++ b/index.js
@@ -69,15 +69,14 @@ exports.handler = ({ body }, lambdaContext, callback) => {
           .then(() => githubRequest(setStatus(context, 'success'), context.userToken))
           .then(() => loggingCallback(null, {'message': `added label ${context.config.label} to ${context.webhook.pull_request.url}`}));
       } else {
-        const nonContributorsIds = nonContributors.map(function(contributorId) {
+        const usersWithoutCLA = nonContributors.map(function (contributorId) {
           return '@' + contributorId;
         });
-        const messageToAppend = `CLA has not been signed by users ${nonContributorsIds.join(', ')}`;
-        return githubRequest(addComment(context, messageToAppend), clabotToken)
+        return githubRequest(addComment(context, usersWithoutCLA), clabotToken)
           .then(() => githubRequest(deleteLabel(context), context.userToken))
           .then(() => githubRequest(setStatus(context, 'failure'), context.userToken))
           .then(() => loggingCallback(null,
-            {'message': `${messageToAppend}, added a comment to ${context.webhook.pull_request.url}`}));
+            {'message': `CLA has not been signed by users ${usersWithoutCLA}, added a comment to ${context.webhook.pull_request.url}`}));
       }
     })
     .catch((err) => {

--- a/index.js
+++ b/index.js
@@ -69,9 +69,8 @@ exports.handler = ({ body }, lambdaContext, callback) => {
           .then(() => githubRequest(setStatus(context, 'success'), context.userToken))
           .then(() => loggingCallback(null, {'message': `added label ${context.config.label} to ${context.webhook.pull_request.url}`}));
       } else {
-        const usersWithoutCLA = nonContributors.map(function (contributorId) {
-          return '@' + contributorId;
-        });
+        const usersWithoutCLA = nonContributors.map(contributorId => `@${contributorId}`)
+          .join(', ');
         return githubRequest(addComment(context, usersWithoutCLA), clabotToken)
           .then(() => githubRequest(deleteLabel(context), context.userToken))
           .then(() => githubRequest(setStatus(context, 'failure'), context.userToken))

--- a/index.js
+++ b/index.js
@@ -69,11 +69,15 @@ exports.handler = ({ body }, lambdaContext, callback) => {
           .then(() => githubRequest(setStatus(context, 'success'), context.userToken))
           .then(() => loggingCallback(null, {'message': `added label ${context.config.label} to ${context.webhook.pull_request.url}`}));
       } else {
-        return githubRequest(addComment(context), clabotToken)
+        const nonContributorsIds = nonContributors.map(function(contributorId) {
+          return '@' + contributorId;
+        });
+        const messageToAppend = `CLA has not been signed by users ${nonContributorsIds.join(', ')}`;
+        return githubRequest(addComment(context, messageToAppend), clabotToken)
           .then(() => githubRequest(deleteLabel(context), context.userToken))
           .then(() => githubRequest(setStatus(context, 'failure'), context.userToken))
           .then(() => loggingCallback(null,
-            {'message': `CLA has not been signed by users [${nonContributors.join(', ')}], added a comment to ${context.webhook.pull_request.url}`}));
+            {'message': `${messageToAppend}, added a comment to ${context.webhook.pull_request.url}`}));
       }
     })
     .catch((err) => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "jsonwebtoken": "^7.4.0",
     "request": "^2.81.0",
-    "parse-github-url": "^0.3.2"
+    "parse-github-url": "^0.3.2",
+    "handlebars": "^4.0.10"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -345,7 +345,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users @foo,@bob, added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, @bob, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -383,7 +383,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, @ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -414,7 +414,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, @ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -458,7 +458,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, @ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -322,7 +322,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -345,7 +345,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo, bob], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo,@bob, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -383,7 +383,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo, ColinEberhardt], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -414,7 +414,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo, ColinEberhardt], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -458,7 +458,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo, ColinEberhardt], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo,@ColinEberhardt, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });
@@ -534,7 +534,7 @@ describe('lambda function', () => {
       lambda.handler(event, {},
         (err, result) => {
           expect(err).toBeNull();
-          expect(result.message).toEqual('CLA has not been signed by users [foo], added a comment to http://foo.com/user/repo/pulls/2');
+          expect(result.message).toEqual('CLA has not been signed by users @foo, added a comment to http://foo.com/user/repo/pulls/2');
           done();
         });
     });


### PR DESCRIPTION
Improved the message added by the cla-bot into the Pull Request, adding the following last sentence:

`\n\nCLA has not been signed by users <list of github IDs>`

where the `<list of github IDs>` includes the `@` symbol to notify users.

You can see it in action on https://github.com/symphonyoss/symphony-java-sample-bots/pull/11

Local testing and running passed.