### PR TITLE
Added a correlation key to logs and report a status URL to allow inspection of logged events

### DIFF
--- a/contributionVerifier.js
+++ b/contributionVerifier.js
@@ -44,12 +44,16 @@ const webhookVerifier = webhookUrl =>
 
 module.exports = (config) => {
   if (config.contributors) {
+    console.info('INFO', 'Checking contributors against the list supplied in the .clabot file');
     return contributorArrayVerifier(config.contributors);
   } else if (config.contributorListGithubUrl) {
+    console.info('INFO', 'Checking contributors against the github URL supplied in the .clabot file');
     return configFileFromGithubUrlVerifier(config.contributorListGithubUrl);
   } else if (config.contributorListUrl) {
+    console.info('INFO', 'Checking contributors against the URL supplied in the .clabot file');
     return configFileFromUrlVerifier(config.contributorListUrl);
   } else if (config.contributorWebhook) {
+    console.info('INFO', 'Checking contributors against the webhook supplied in the .clabot file');
     return webhookVerifier(config.contributorWebhook);
   }
   throw new Error('A mechanism for verifying contributors has not been specified');

--- a/event.json
+++ b/event.json
@@ -2,17 +2,17 @@
   "body": {
     "action": "opened",
     "pull_request": {
-      "url": "https://api.github.com/repos/symphonyoss/symphony-java-sample-bots/pulls/11",
-      "issue_url": "https://api.github.com/repos/symphonyoss/symphony-java-sample-bots/issues/11",
+      "url": "https://api.github.com/repos/ColinEberhardt/clabot-test/pulls/26",
+      "issue_url": "https://api.github.com/repos/ColinEberhardt/clabot-test/issues/26",
       "head": {
-        "sha": "df0e813acac48351b91712bba00d39e44c5ffa63"
+        "sha": "9d88b013f0fb3e3a25ed3b67705cc80eb1a56e0e"
       }
     },
     "repository": {
-      "url": "https://api.github.com/repos/symphonyoss/symphony-java-sample-bots"
+      "url": "https://api.github.com/repos/ColinEberhardt/clabot-test"
     },
     "installation": {
-      "id": 25077
+      "id": 32613
     }
   }
 }

--- a/githubApi.js
+++ b/githubApi.js
@@ -49,11 +49,12 @@ exports.getCommits = ({ webhook }) => ({
   method: 'GET'
 });
 
-exports.setStatus = ({ webhook }, state) => ({
+exports.setStatus = ({ webhook, correlationKey }, state) => ({
   url: `${webhook.repository.url}/statuses/${webhook.pull_request.head.sha}`,
   body: {
     state,
-    context: 'verification/cla-signed'
+    context: 'verification/cla-signed',
+    target_url: `https://colineberhardt.github.io/cla-bot/logs?correlationKey=${correlationKey}`
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const contributionVerifier = require('./contributionVerifier');
 const installationToken = require('./installationToken');
+const uuid = require('uuid/v1');
+const is = require('is_js');
 const { githubRequest, getOrgConfig, getReadmeUrl, getFile, addLabel, getCommits, setStatus, addComment, deleteLabel } = require('./githubApi');
 
 const defaultConfig = JSON.parse(fs.readFileSync('default.json'));
@@ -12,9 +14,9 @@ const validAction = action =>
   ['opened', 'synchronize'].indexOf(action) !== -1;
 
 exports.handler = ({ body }, lambdaContext, callback) => {
-  const loggingCallback = (err, message) => {
-    console.info('callback', err, message);
-    callback(err, message);
+  const loggingCallback = (error, message) => {
+    console.info('DEBUG', 'integration webhook callback response', { error, message });
+    callback(error, message);
   };
 
   if (!validAction(body.action)) {
@@ -22,23 +24,41 @@ exports.handler = ({ body }, lambdaContext, callback) => {
     return;
   }
 
-  const context = {
-    webhook: body
+  // adapt the console messages to add a correlation key
+  const correlationKey = uuid();
+  // we use console.info because AWS logs this, however, we can suppress console.info
+  // when running the unit tests to given a cleaner output
+  const adaptee = console.info;
+  console.info = (level, message, detail) => {
+    adaptee({
+      correlationKey,
+      level,
+      message,
+      detail
+    });
   };
 
-  console.info(`Checking CLAs for PR ${context.webhook.pull_request.url}`);
+  const context = {
+    webhook: body,
+    correlationKey
+  };
+
+  console.info('INFO', `Checking CLAs for pull request ${context.webhook.pull_request.url}`);
 
   Promise.resolve()
     .then(() => {
       // if we are running as an integration, obtain the required integration token
       if (process.env.INTEGRATION_ENABLED && process.env.INTEGRATION_ENABLED === 'true') {
+        console.info('INFO', 'Bot installed as an integration, obtaining installation token');
         return installationToken(context.webhook.installation.id);
       } else {
+        console.info('INFO', 'Bot installed as a webhook, using access token');
         return process.env.GITHUB_ACCESS_TOKEN;
       }
     })
     .then((token) => {
       context.userToken = token;
+      console.info('INFO', 'Attempting to obtain organisation level .clabot file URL');
       return githubRequest(getOrgConfig(context), context.userToken);
     })
     // if the request to obtain the org-level .clabot file returns a non 2xx response
@@ -47,39 +67,50 @@ exports.handler = ({ body }, lambdaContext, callback) => {
     .catch(() => ({ noOrgConfig }))
     .then((orgConfig) => {
       if ('noOrgConfig' in orgConfig) {
-        console.info('Resolving .clabot at project level');
+        console.info('INFO', 'Organisation configuration not found, resolving .clabot URL at project level');
         return githubRequest(getReadmeUrl(context), context.userToken);
       } else {
-        console.info('Using org-level .clabot');
+        console.info('INFO', 'Organisation configuration not found');
         return orgConfig;
       }
     })
-    .then(orgConfig => githubRequest(getFile(orgConfig), context.userToken))
+    .then((orgConfig) => {
+      console.info('INFO', `Obtaining .clabot configuration file from ${orgConfig.download_url}`);
+      return githubRequest(getFile(orgConfig), context.userToken);
+    })
     .then((config) => {
+      if (!is.json(config)) {
+        throw new Error('The .clabot file is not valid JSON');
+      }
+      console.info('INFO', 'Obtaining the list of commits for the pull request');
       context.config = Object.assign({}, defaultConfig, config);
       return githubRequest(getCommits(context), context.userToken);
     })
     .then((commits) => {
+      console.info('INFO', `A total of ${commits.length} were found, checking CLA status for committers`);
       const committers = commits.map(c => c.author.login);
       const verifier = contributionVerifier(context.config);
       return verifier(committers, context.userToken);
     })
     .then((nonContributors) => {
       if (nonContributors.length === 0) {
+        console.info('INFO', 'All contributors have a signed CLA, adding success status to the pull request and a label');
         return githubRequest(addLabel(context), context.userToken)
           .then(() => githubRequest(setStatus(context, 'success'), context.userToken))
           .then(() => loggingCallback(null, { message: `added label ${context.config.label} to ${context.webhook.pull_request.url}` }));
       } else {
         const usersWithoutCLA = nonContributors.map(contributorId => `@${contributorId}`)
           .join(', ');
+        console.info('INFO', `The contributors ${usersWithoutCLA} have not signed the CLA, adding error status to the pull request`);
         return githubRequest(addComment(context, usersWithoutCLA), context.userToken)
           .then(() => githubRequest(deleteLabel(context), context.userToken))
-          .then(() => githubRequest(setStatus(context, 'failure'), context.userToken))
+          .then(() => githubRequest(setStatus(context, 'error'), context.userToken))
           .then(() => loggingCallback(null,
             { message: `CLA has not been signed by users ${usersWithoutCLA}, added a comment to ${context.webhook.pull_request.url}` }));
       }
     })
     .catch((err) => {
-      loggingCallback(err.toString());
+      githubRequest(setStatus(context, 'failure'), context.userToken)
+        .then(() => loggingCallback(err.toString()));
     });
 };

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "handlebars": "^4.0.10",
+    "is_js": "^0.9.0",
     "jsonwebtoken": "^7.4.0",
-    "request": "^2.81.0",
     "parse-github-url": "^0.3.2",
-    "handlebars": "^4.0.10"
+    "request": "^2.81.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/requestAsPromise.js
+++ b/requestAsPromise.js
@@ -1,14 +1,16 @@
 const request = require('request');
 
-module.exports = opts => new Promise((resolve, reject) => {
-  console.info('API Request', opts.url, JSON.stringify(opts, null, 2));
-  request(opts, (error, response, body) => {
-    console.info('API Response', opts.url, error, response && response.statusCode, JSON.stringify(body, null, 2));
+module.exports = options => new Promise((resolve, reject) => {
+  console.info('DEBUG', 'API Request', { url: options.url, options });
+  request(options, (error, response, body) => {
     if (error) {
+      console.info('DEBUG', 'API Response', { error });
       reject(error.toString());
     } else if (response && response.statusCode && !response.statusCode.toString().startsWith('2')) {
-      reject(new Error(`API request ${opts.url} failed with status ${response.statusCode}`));
+      console.info('DEBUG', 'API Response', { statusCode: response.statusCode });
+      reject(new Error(`API request ${options.url} failed with status ${response.statusCode}`));
     } else {
+      console.info('DEBUG', 'API Response', { url: options.url, body });
       resolve(body);
     }
   });


### PR DESCRIPTION
@maoo this might interest you ...

I've been scratching my head about how to expose configuration issues and general bot failures. What I've come up with is the following:
- The messages logged as a result of a bot 'session' all have a unique correlation key
- When the PR status is updated, there is a link to a detail page along with this key
- I'm going to write a simple app that sits at this URL and returns the log messages relating to this key.

This gives both visibility, and privacy - i.e. you cannot see someone elses messages without knowing their key.