### PR TITLE
Resolving issue 74 - TypeError: Cannot read property 'login' of null

### DIFF
--- a/FINOS-DEPLOY.md
+++ b/FINOS-DEPLOY.md
@@ -1,0 +1,12 @@
+# FINOS cla-bot deploy
+
+1. Check environment setup in `src/serverless.env.yml` (`staging` and `prod`)
+2. Run NPM
+```
+npm install
+npm audit fix --force
+```
+3. Deploy
+```
+serverless deploy --stage staging
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "execute:bot": "serverless invoke local --function cla-bot --path cla-bot/dev/event.json --stage dev",
+    "execute:bot": "serverless invoke local --function cla-bot --path src/dev/event.json --stage dev",
     "test": "npm run lint && jasmine",
     "lint": "eslint \"src/*.js\"",
     "prettier:fix": "prettier --write \"{src,spec}/**/*.js\""

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,12 +9,12 @@ provider:
       Action:
         - s3:PutObject
         - s3:PutObjectAcl
-      Resource: "arn:aws:s3:::${file(./cla-bot/serverless.env.yml):${opt:stage}.LOGGING_BUCKET}/*"
-      
+      Resource: "arn:aws:s3:::${file(./src/serverless.env.yml):${opt:stage}.LOGGING_BUCKET}/*"
+
 functions:
   cla-bot:
-    handler: cla-bot/index.handler
-    environment: ${file(./cla-bot/serverless.env.yml):${opt:stage}}
+    handler: src/index.handler
+    environment: ${file(./src/serverless.env.yml):${opt:stage}}
     events:
       - http:
           path: cla-check

--- a/src/default.json
+++ b/src/default.json
@@ -1,4 +1,5 @@
 {
+  "messageMissingEmail": "Thank you for your pull request and welcome to our community. We could not parse the GitHub identity of the following contributors: **{{unidentifiedUsers}}**.\nThis is most likely caused by a git client misconfiguration; please make sure to:\n1. check if your git client is configured with an email to sign commits `git config --list | grep email`\n2. If not, set it up using `git config --global user.email email@example.com`\n3. Make sure that the git commit email is configured in your GitHub account settings, see https://github.com/settings/emails",
   "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don\"t seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please contact the project maintainers to get yourself added.",
   "label": "cla-signed",
   "recheckComment": "The cla-bot has been summoned, and re-checked this pull request!"

--- a/src/githubApi.js
+++ b/src/githubApi.js
@@ -78,13 +78,23 @@ exports.addRecheckComment = (issueUrl, recheckComment) => ({
   }
 });
 
-exports.addComment = (issueUrl, message, usersWithoutCLA) => {
+exports.addCommentNoCLA = (issueUrl, message, usersWithoutCLA) => {
   // TODO: move this logic out of this file
   const template = handlebars.compile(message);
   return {
     url: `${issueUrl}/comments`,
     body: {
       body: template({ usersWithoutCLA })
+    }
+  };
+};
+
+exports.addCommentUnidentified = (issueUrl, message, unidentifiedUsers) => {
+  const template = handlebars.compile(message);
+  return {
+    url: `${issueUrl}/comments`,
+    body: {
+      body: template({ unidentifiedUsers })
     }
   };
 };


### PR DESCRIPTION
I managed to catch when a PR contains unidentifiable authors, which are all those GitHub users who haven't properly set their GitHub email address and/or `git config email.address` local setup.

I've added a new configuration in the `.clabot` that defaults to the following:
```
  "messageMissingEmail": "Thank you for your pull request and welcome to our community. We could not parse the GitHub identity of the following contributors: **{{unidentifiedUsers}}**.\nThis is most likely caused by a git client misconfiguration; please make sure to:\n1. check if your git client is configured with an email to sign commits `git config --list | grep email`\n2. If not, set it up using `git config --global user.email email@example.com`\n3. Make sure that the git commit email is configured in your GitHub account settings, see https://github.com/settings/emails",
```

I've changed the `index.js` and implemented lambda specs to test the specific corner case, `npm test` is happy. I've also tested it on our staging account, see screenshot below.

<img width="817" alt="screenshot 2018-11-22 at 22 54 33" src="https://user-images.githubusercontent.com/327285/48922824-9adf2880-eea9-11e8-99cb-a2d59f41ec24.png">

Eager to hear your thoughts. Thanks!