### PR TITLE
fixed s3 issue, see #101

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ exports.handler = constructHandler(async webhook => {
   const logFile = `https://s3.amazonaws.com/${
     process.env.LOGGING_BUCKET
   }/${logUrl}`;
-  logger.logFile(logFile);
+  logger.logFile(logUrl);
 
   if (webhook.action === "created") {
     if (!commentSummonsBot(webhook.comment.body)) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -42,7 +42,7 @@ const logger = {
       s3
         .putObject({
           Body: loggedMessages.join("\r\n"),
-          Bucket: "cla-bot",
+          Bucket: process.env.LOGGING_BUCKET,
           Key: logFile,
           ACL: "public-read",
           ContentType: "text/plain"
@@ -51,7 +51,7 @@ const logger = {
       s3
         .putObject({
           Body: detailedLoggedMessages.join("\r\n"),
-          Bucket: "cla-bot",
+          Bucket: process.env.LOGGING_BUCKET,
           Key: `${id}-DEBUG`,
           ACL: "public-read",
           ContentType: "text/plain"


### PR DESCRIPTION
Replaced hardcoded `"cla-bot"` string with `process.env.LOGGING_BUCKET`.

Also found out that `index.js` should pass `logUrl` (instead of `logFile`) to `logger.logFile()`, otherwise it will create a wrong folder structure within S3.

Tests and lint are passing.