### PR TITLE
Three line updated to project src directory due to Prettier linting issues

### DIFF
--- a/src/githubApi.js
+++ b/src/githubApi.js
@@ -4,9 +4,7 @@ const gh = require("parse-github-url");
 
 const getOrgConfigUrl = repositoryUrl => {
   const ghData = gh(repositoryUrl);
-  const ghUrl = `https://${ghData.host}/repos/${
-    ghData.owner
-  }/clabot-config/contents/.clabot`;
+  const ghUrl = `https://${ghData.host}/repos/${ghData.owner}/clabot-config/contents/.clabot`;
   return ghUrl;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -101,9 +101,7 @@ exports.handler = constructHandler(async webhook => {
   // determine the URL for storing the event log
   const org = pullRequestUrl.split("/")[4];
   const logUrl = `${org}-${uuid()}`;
-  const logFile = `https://s3.amazonaws.com/${
-    process.env.LOGGING_BUCKET
-  }/${logUrl}`;
+  const logFile = `https://s3.amazonaws.com/${process.env.LOGGING_BUCKET}/${logUrl}`;
   logger.logFile(logUrl);
 
   if (webhook.action === "created") {

--- a/src/requestAsPromise.js
+++ b/src/requestAsPromise.js
@@ -18,9 +18,7 @@ module.exports = options =>
         });
         reject(
           new Error(
-            `API request ${options.url} failed with status ${
-              response.statusCode
-            }`
+            `API request ${options.url} failed with status ${response.statusCode}`
           )
         );
       } else {


### PR DESCRIPTION
The issues below were flagged during build and fixed / committed to this pull request.

/Users/jamesmcleod/Projects/FINOS/cla-bot/src/githubApi.js
  7:49  error  Replace `⏎····ghData.owner⏎··` with `ghData.owner`  prettier/prettier

/Users/jamesmcleod/Projects/FINOS/cla-bot/src/index.js
  104:47  error  Replace `⏎····process.env.LOGGING_BUCKET⏎··` with `process.env.LOGGING_BUCKET`  prettier/prettier

/Users/jamesmcleod/Projects/FINOS/cla-bot/src/requestAsPromise.js
  21:62  error  Replace `⏎··············response.statusCode⏎············` with `response.statusCode`  prettier/prettier 