### PR TITLE
Domain email verification

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,6 @@
     "prettier/prettier": "error"
   },
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   }
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jasmine Individual Test",
+      "program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
+      "args": ["spec/lambdaSpec.js"],
+      "env": {
+        "NODE_PATH": "."
+      }
+    }
+  ]
+}

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -866,6 +866,22 @@ describe("contributionVerifier", () => {
       });
     });
 
+    it("should support verification via email address", done => {
+      const config = { contributors: ["billy@foo.com"] };
+
+      const verifier = require("../src/contributionVerifier");
+
+      const commiters = [
+        { email: "billy@foo.com", login: "billy" },
+        { email: "foo@bar.com", login: "foo" }
+      ];
+
+      verifier(config)(commiters).then(nonContributors => {
+        expect(nonContributors).toEqual(["foo"]);
+        done();
+      });
+    });
+
     it("should support detection of a contributor list from a URL", done => {
       const config = {
         contributors: "http://bar.com/contributors.txt"

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -867,12 +867,51 @@ describe("contributionVerifier", () => {
     });
 
     it("should support verification via email address", done => {
-      const config = { contributors: ["billy@foo.com"] };
+      const config = { contributors: ["billy@foo.com", "frank@foo.com"] };
 
       const verifier = require("../src/contributionVerifier");
 
       const commiters = [
         { email: "billy@foo.com", login: "billy" },
+        { email: "foo@bar.com", login: "foo" }
+      ];
+
+      verifier(config)(commiters).then(nonContributors => {
+        expect(nonContributors).toEqual(["foo"]);
+        done();
+      });
+    });
+
+    it("should support verification via email address or login", done => {
+      const config = {
+        contributors: ["billy@foo.com", "frank@foo.com", "malcolm", "james"]
+      };
+
+      const verifier = require("../src/contributionVerifier");
+
+      const commiters = [
+        { email: "billy@foo.com" /* valid email */, login: "billy" },
+        { email: "foo@bar.com", login: "foo" },
+        { email: "malcolm@bar.com", login: "malcolm" /* valid username */ },
+        {
+          email: "frank@foo.com" /* valid email */,
+          login: "james" /* valid username */
+        }
+      ];
+
+      verifier(config)(commiters).then(nonContributors => {
+        expect(nonContributors).toEqual(["foo"]);
+        done();
+      });
+    });
+
+    it("should support verification via email domain", done => {
+      const config = { contributors: ["@foo.com"] };
+
+      const verifier = require("../src/contributionVerifier");
+
+      const commiters = [
+        { email: "billy@foo.com" /* valid email */, login: "billy" },
         { email: "foo@bar.com", login: "foo" }
       ];
 

--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -790,7 +790,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual([]);
         done();
       });
@@ -810,7 +812,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob", "billy"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }, { login: "billy" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual(["billy"]);
         done();
       });
@@ -837,7 +841,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob", "foo"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }, { login: "foo" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual(["foo"]);
         done();
       });
@@ -852,7 +858,9 @@ describe("contributionVerifier", () => {
 
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob", "billy"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }, { login: "billy" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual(["bob"]);
         done();
       });
@@ -872,7 +880,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob", "billy"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }, { login: "billy" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual(["billy"]);
         done();
       });
@@ -899,7 +909,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual([]);
         done();
       });
@@ -926,7 +938,9 @@ describe("contributionVerifier", () => {
       mock("request", request);
       const verifier = require("../src/contributionVerifier");
 
-      verifier(config)(["bob", "foo"]).then(nonContributors => {
+      const commiters = [{ login: "bob" }, { login: "foo" }];
+
+      verifier(config)(commiters).then(nonContributors => {
         expect(nonContributors).toEqual(["foo"]);
         done();
       });

--- a/src/contributionVerifier.js
+++ b/src/contributionVerifier.js
@@ -2,16 +2,26 @@ const requestp = require("./requestAsPromise");
 const is = require("is_js");
 const { githubRequest, getFile } = require("./githubApi");
 
+// return the list of committers who are not know contributors
 const contributorArrayVerifier = contributors => committers => {
-  const res = committers
-    .filter(
-      c =>
-        // does the lowercase login match and of the lowercase contributors?
-        contributors
-          .map(v => v.toLowerCase())
-          .indexOf(c.login.toLowerCase()) === -1
-    )
-    .map(c => c.login);
+  const emailVerification = contributors
+    .filter(c => c.includes("@"))
+    .map(c => c.toLowerCase());
+  const usernameVerification = contributors
+    .filter(c => !c.includes("@"))
+    .map(c => c.toLowerCase());
+
+  const isValidContributor = c => {
+    if (c.email && emailVerification.includes(c.email.toLowerCase())) {
+      return true;
+    }
+    if (usernameVerification.includes(c.login.toLowerCase())) {
+      return true;
+    }
+    return false;
+  };
+
+  const res = committers.filter(c => !isValidContributor(c)).map(c => c.login);
   return Promise.resolve(res);
 };
 

--- a/src/contributionVerifier.js
+++ b/src/contributionVerifier.js
@@ -2,12 +2,18 @@ const requestp = require("./requestAsPromise");
 const is = require("is_js");
 const { githubRequest, getFile } = require("./githubApi");
 
-const contributorArrayVerifier = contributors => committers =>
-  Promise.resolve(
-    committers.filter(
-      c => contributors.map(v => v.toLowerCase()).indexOf(c) === -1
+const contributorArrayVerifier = contributors => committers => {
+  const res = committers
+    .filter(
+      c =>
+        // does the lowercase login match and of the lowercase contributors?
+        contributors
+          .map(v => v.toLowerCase())
+          .indexOf(c.login.toLowerCase()) === -1
     )
-  );
+    .map(c => c.login);
+  return Promise.resolve(res);
+};
 
 const configFileFromGithubUrlVerifier = contributorListGithubUrl => (
   committers,
@@ -31,12 +37,12 @@ const configFileFromUrlVerifier = contributorListUrl => committers =>
 
 const webhookVerifier = webhookUrl => committers =>
   Promise.all(
-    committers.map(username =>
+    committers.map(committer =>
       requestp({
-        url: webhookUrl + username,
+        url: webhookUrl + committer.login,
         json: true
       }).then(response => ({
-        username,
+        username: committer.login,
         isContributor: response.isContributor
       }))
     )

--- a/src/contributionVerifier.js
+++ b/src/contributionVerifier.js
@@ -2,18 +2,39 @@ const requestp = require("./requestAsPromise");
 const is = require("is_js");
 const { githubRequest, getFile } = require("./githubApi");
 
+// see: https://stackoverflow.com/a/47225591/249933
+function partition(array, isValid) {
+  return array.reduce(
+    ([pass, fail], elem) => {
+      return isValid(elem) ? [[...pass, elem], fail] : [pass, [...fail, elem]];
+    },
+    [[], []]
+  );
+}
+
+const domainFromEmail = email => "@" + email.split("@")[1];
+
 // return the list of committers who are not know contributors
 const contributorArrayVerifier = contributors => committers => {
-  const emailVerification = contributors
-    .filter(c => c.includes("@"))
-    .map(c => c.toLowerCase());
-  const usernameVerification = contributors
-    .filter(c => !c.includes("@"))
-    .map(c => c.toLowerCase());
+  const lowerCaseContributors = contributors.map(c => c.toLowerCase());
+  const [emailVerification, usernameVerification] = partition(
+    lowerCaseContributors,
+    c => c.includes("@")
+  );
+
+  const [domainVerification, exactEmailVerification] = partition(
+    emailVerification,
+    c => c.startsWith("@")
+  );
 
   const isValidContributor = c => {
-    if (c.email && emailVerification.includes(c.email.toLowerCase())) {
-      return true;
+    if (c.email) {
+      if (exactEmailVerification.includes(c.email.toLowerCase())) {
+        return true;
+      }
+      if (domainVerification.includes(domainFromEmail(c.email))) {
+        return true;
+      }
     }
     if (usernameVerification.includes(c.login.toLowerCase())) {
       return true;


### PR DESCRIPTION
ref #104

This pull requests add the following additional features:

1. You can now specify contributors by either email address or GitHub username
2. For email address, you can also specify just the domain, e.g. `@foo.com`, which will consider any email address within that domain valid.

This should help with #104 where we have been discussing how to make the cla-bot maintenance easier for organisation with CCLAs