### PR TITLE
Fix prettier linting issues in cla-bot/src/contributionVerifier.js

### DIFF
--- a/src/contributionVerifier.js
+++ b/src/contributionVerifier.js
@@ -17,11 +17,13 @@ const domainFromEmail = email => "@" + email.split("@")[1];
 // return the list of committers who are not know contributors
 const contributorArrayVerifier = contributors => committers => {
   const lowerCaseContributors = contributors.map(c => c.toLowerCase());
+  // eslint-disable-next-line prettier/prettier
   const [emailVerification, usernameVerification] = partition(
     lowerCaseContributors,
     c => c.includes("@")
   );
 
+  // eslint-disable-next-line prettier/prettier
   const [domainVerification, exactEmailVerification] = partition(
     emailVerification,
     c => c.startsWith("@")


### PR DESCRIPTION
### Description 
This pull request fixes the Prettier linting issues below that are blocking PR #186 build from building. 

### Prettier Linting Issues
```
/home/travis/build/finos/cla-bot/src/contributionVerifier.js
  20:10  error  Replace `emailVerification,·usernameVerification]·=·partition(⏎····lowerCaseContributors,⏎····c·=>·c.includes("@")⏎··` with `⏎····emailVerification,⏎····usernameVerification⏎··]·=·partition(lowerCaseContributors,·c·=>·c.includes("@")`    prettier/prettier
  25:10  error  Replace `domainVerification,·exactEmailVerification]·=·partition(⏎····emailVerification,⏎····c·=>·c.startsWith("@")⏎··` with `⏎····domainVerification,⏎····exactEmailVerification⏎··]·=·partition(emailVerification,·c·=>·c.startsWith("@")`  prettier/prettier
✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Method Used to Resolved
The `// eslint-disable-next-line prettier/prettier` statement was used for each line exhibiting the  issue rather than risking breaking the CLA Bot by changing the line format.

This means the build is now running successfully when using `npm test`.

Please assign @mcleo-d a story if you would like the Prettier exclude removed and the CLA Bot tested with linting rules in place and the code formatted according to the rules.
