### PR TITLE
fix: updated installation token endpoint

### DIFF
--- a/spec/lambdaSpec.js
+++ b/spec/lambdaSpec.js
@@ -100,7 +100,7 @@ describe("lambda function", () => {
         }
       },
       // next use the integration API to obtain an access token
-      "https://api.github.com/installations/1000/access_tokens": {
+      "https://api.github.com/app/installations/1000/access_tokens": {
         body: {
           token: installationToken
         }

--- a/src/installationToken.js
+++ b/src/installationToken.js
@@ -12,7 +12,7 @@ module.exports = installationId => {
   });
 
   return requestp({
-    url: `https://api.github.com/installations/${installationId}/access_tokens`,
+    url: `https://api.github.com/app/installations/${installationId}/access_tokens`,
     json: true,
     headers: {
       Authorization: `Bearer ${integrationToken}`,


### PR DESCRIPTION
GitHub have [changed one of the endpoints](https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/) that this bot uses. I've fixed and tested this change for my bot installation:

https://github.com/ColinEberhardt/cla-bot/pull/13

This PR contributes the fix back to FINOS.